### PR TITLE
guid could also be an email address

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
           <li>In the <code>id</code> of the <code>package.json</code> for an SDK add-on</li>
           <li>On <a href="https://addons.mozilla.org">addons.mozilla.org</a>, go to <code>Tools</code> &gt; <code>Manage My Submissions</code> &gt; and select the add-on, then scroll down to <code>Technical Details</code></li>
         </ul>
-        Your add-on guid should look something like this: {F33233B3-EDB1-41f4-8482-917AB190E647}
+        Your add-on guid should either be an email address, or something that looks like this: {F33233B3-EDB1-41f4-8482-917AB190E647}
       </p>
 
       <form class="form-inline">

--- a/script.js
+++ b/script.js
@@ -79,6 +79,6 @@ function show(element) {
 
 // The data.js file can take a while on slow connections.
 var loading = document.getElementsByClassName('btn')[0];
-loading.innerHTML = 'Look up';
+loading.textContent = 'Look up';
 loading.disabled = null;
 loading.classList.add('btn-success');


### PR DESCRIPTION
Follow-up from #3. Turns out, we already check for the application ids. So we only want to add that the id could also be an email.

@atsay r?