### PR TITLE
Lock down en-US locale for mdn

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <p>Requires Firefox, Chrome or Opera. Because it uses <a href="https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode">TextEncoder</a>.</p>
       </div>
 
-      <p>There are a lot of <a href="https://blog.mozilla.org/addons/2015/08/21/the-future-of-developing-firefox-add-ons/" target="_blank">changes</a> coming up in add-on development for Firefox. By the end of 2017, we will transition to <a href="https://wiki.mozilla.org/WebExtensions" target="_blank">WebExtensions</a> as the standard for creating add-ons. Over the same period of time, existing methods for add-on development such as XUL/XPCOM will be deprecated. <a href="https://developer.mozilla.org/Add-ons/Working_with_multiprocess_Firefox" target="_blank">Multi-process Firefox</a> (aka Electrolysis, or e10s) is also rolling out, which means some add-on developers will have to update their add-ons more than once.</p>
+      <p>There are a lot of <a href="https://blog.mozilla.org/addons/2015/08/21/the-future-of-developing-firefox-add-ons/" target="_blank">changes</a> coming up in add-on development for Firefox. By the end of 2017, we will transition to <a href="https://wiki.mozilla.org/WebExtensions" target="_blank">WebExtensions</a> as the standard for creating add-ons. Over the same period of time, existing methods for add-on development such as XUL/XPCOM will be deprecated. <a href="https://developer.mozilla.org/en-US/Add-ons/Working_with_multiprocess_Firefox" target="_blank">Multi-process Firefox</a> (aka Electrolysis, or e10s) is also rolling out, which means some add-on developers will have to update their add-ons more than once.</p>
 
       <p>You can use the tool below to check the compatibility of your add-on as it relates to these changes, and what your options are for transitioning if you are affected.</p>
 
@@ -47,7 +47,7 @@
       <div class="answer alert alert-warning" role="alert" id="sdk" style="display: none">
         <h3>SDK add-on using low level APIs</h3>
         <p>
-            We think this is an SDK add-on that uses <a href="https://developer.mozilla.org/Add-ons/SDK/Low-Level_APIs" target="_blank">low level APIs</a> that will break with Multi-process Firefox (aka Electrolysis or e10s).
+            We think this is an SDK add-on that uses <a href="https://developer.mozilla.org/en-US/Add-ons/SDK/Low-Level_APIs" target="_blank">low level APIs</a> that will break with Multi-process Firefox (aka Electrolysis or e10s).
             <a class="btn btn-primary" href="https://wiki.mozilla.org/Add-ons/developer/communication#1.29_Has_SDK_add-on_using_low_level_APIs">More Information</a>
         </p>
       </div>
@@ -62,9 +62,9 @@
 
       <div class="answer alert alert-warning" role="alert" id="sdk-high" style="display: none">
         <h3>SDK add-on using high level APIs</h3>
-        <p>We think this is an SDK add-on using <a href="https://developer.mozilla.org/Add-ons/SDK/High-Level_APIs" target="_blank">high level APIs</a>. Your add-on will probably continue to work without problems, but we recommend you start looking into WebExtensions.</p>
+        <p>We think this is an SDK add-on using <a href="https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs" target="_blank">high level APIs</a>. Your add-on will probably continue to work without problems, but we recommend you start looking into WebExtensions.</p>
 
-        <p>Also, please note that as of March 2016, SDK add-ons that were built using the cfx tool (Jetpack version 1.17 and lower) need to be repackaged using the <a href="https://developer.mozilla.org/Add-ons/SDK/Tools/cfx_to_jpm" target="_blank">newer jpm tool</a> in order to continue being compatible with Firefox.
+        <p>Also, please note that as of March 2016, SDK add-ons that were built using the cfx tool (Jetpack version 1.17 and lower) need to be repackaged using the <a href="https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx_to_jpm" target="_blank">newer jpm tool</a> in order to continue being compatible with Firefox.
             <a class="btn btn-primary" href="https://wiki.mozilla.org/Add-ons/developer/communication#3.29_Has_SDK_add-on_using_only_high_level_SDKs">More Information</a>
         </p>
       </div>


### PR DESCRIPTION
Fixes #10

Wiki pages might not exist in every locale so we should just use en-US always to make sure users don't ever see a 404.

r? @atsay or @andym